### PR TITLE
fix: return null if window.performance.timing is invalid

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@
     'loadEventStart'
   ];
 
-  if (!win || !win.performance || typeof win.performance !== 'object') {
+  if (!win || !win.performance || typeof win.performance !== 'object' || !win.performance.timing) {
     return timing2;
   }
 


### PR DESCRIPTION
* fix: when run in jest, `window.performance` exists, but `performance.timing` is undefined.